### PR TITLE
update Software Controler to v5.5.6

### DIFF
--- a/bin/aws-userdata-amazon-linux.sh
+++ b/bin/aws-userdata-amazon-linux.sh
@@ -4,9 +4,9 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 # version: 2022.07.21
 # Omada Controller: https://community.tp-link.com/en/business/forum/topic/548752
-# Linux:            https://static.tp-link.com/upload/software/2022/202207/20220729/Omada_SDN_Controller_v5.4.6_Linux_x64.tar.gz
+# Linux:            https://static.tp-link.com/upload/software/2022/202208/20220822/Omada_SDN_Controller_v5.5.6_Linux_x64.tar.gz
 
-OMADAURL="https://static.tp-link.com/upload/software/2022/202207/20220729/Omada_SDN_Controller_v5.4.6_Linux_x64.tar.gz" && echo "URL set: ${OMADAURL}"
+OMADAURL="https://static.tp-link.com/upload/software/2022/202208/20220822/Omada_SDN_Controller_v5.5.6_Linux_x64.tar.gz" && echo "URL set: ${OMADAURL}"
 
 SetVars() {
     OMADATARGZ=$(echo "${OMADAURL}" | awk '{split($0,a,"/"); print a[9]}') && echo "Omada installer filename set: ${OMADATARGZ}"

--- a/bin/install-omada-on-amazon-linux.sh
+++ b/bin/install-omada-on-amazon-linux.sh
@@ -4,9 +4,9 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 # Omada Controller installer sources: https://community.tp-link.com/en/business/forum/topic/548752
-# Linux:            https://static.tp-link.com/upload/software/2022/202207/20220729/Omada_SDN_Controller_v5.4.6_Linux_x64.tar.gz
+# Linux:            https://static.tp-link.com/upload/software/2022/202208/20220822/Omada_SDN_Controller_v5.5.6_Linux_x64.tar.gz
 
-OMADAURL="https://static.tp-link.com/upload/software/2022/202207/20220729/Omada_SDN_Controller_v5.4.6_Linux_x64.tar.gz" && echo "URL set: ${OMADAURL}"
+OMADAURL="https://static.tp-link.com/upload/software/2022/202208/20220822/Omada_SDN_Controller_v5.5.6_Linux_x64.tar.gz" && echo "URL set: ${OMADAURL}"
 
 # Set vars
 OMADATARGZ=$(echo "${OMADAURL}" | awk '{split($0,a,"/"); print a[9]}') && echo "Omada installer filename set: ${OMADATARGZ}"

--- a/bin/install-omada-on-rhel8-linux.sh
+++ b/bin/install-omada-on-rhel8-linux.sh
@@ -4,12 +4,12 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 # Omada Controller installer sources: https://community.tp-link.com/en/business/forum/topic/548752
-# Linux:            https://static.tp-link.com/upload/software/2022/202207/20220729/Omada_SDN_Controller_v5.4.6_Linux_x64.tar.gz
+# Linux:            https://static.tp-link.com/upload/software/2022/202208/20220822/Omada_SDN_Controller_v5.5.6_Linux_x64.tar.gz
 
 # Info for RHEL and Omada Software Controler
 #   Omada Software Controller require jsvc but on Red Hat 8 jsvc is not available per defauls/for free
 #   you have to buy a license.
-OMADAURL="https://static.tp-link.com/upload/software/2022/202207/20220729/Omada_SDN_Controller_v5.4.6_Linux_x64.tar.gz" && echo "URL set: ${OMADAURL}"
+OMADAURL="https://static.tp-link.com/upload/software/2022/202208/20220822/Omada_SDN_Controller_v5.5.6_Linux_x64.tar.gz" && echo "URL set: ${OMADAURL}"
 
 # Set vars
 OMADATARGZ=$(echo "${OMADAURL}" | awk '{split($0,a,"/"); print a[9]}') && echo "Omada installer filename set: ${OMADATARGZ}"


### PR DESCRIPTION
- Update Software Controller tar.gz to version [v5.5.6](https://static.tp-link.com/upload/software/2022/202208/20220822/Omada_SDN_Controller_v5.5.6_Linux_x64.tar.gz)